### PR TITLE
Add OpenPaw to Chat and messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A curated list of open source, multiplatform and self hosted communication tools
 
 * [Revolt](https://github.com/revoltchat) - Revolt is an open source user-first chat platform.
 
+* [OpenPaw](https://github.com/daxaur/openpaw) - Open-source AI-powered CLI that connects to Slack, Discord, Email, iMessage, WhatsApp, and Telegram from a single interface. Run via `npx pawmode`.
+
 
 ## Chat bots
 * [Rasa](https://rasa.com/) - Rasa Open Source is a machine learning framework to automate text- and voice-based assistants.


### PR DESCRIPTION
Hey! Adding [OpenPaw](https://github.com/daxaur/openpaw) to the Chat and messaging section.

It's an open-source CLI tool that connects to multiple communication platforms from a single interface — Slack, Discord, Email (Gmail/IMAP), iMessage, WhatsApp, and Telegram. MIT licensed, runs via `npx pawmode`.

Seemed like a good fit for this list since it bridges a bunch of different messaging platforms together. Let me know if you'd prefer it in a different section!