### PR TITLE
Add HeyRobyn - Native macOS unified inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A curated list of open source, multiplatform and self hosted communication tools
 
 * [Franz](https://github.com/meetfranz/franz) - Franz is a free messaging app for services like WhatsApp, Slack, Messenger and many more.
 
+* [HeyRobyn](https://heyrobyn.ai) - Native macOS unified inbox for email, Slack, and GitHub. Built with SwiftUI for privacy-first, on-device communication management.
+
 * [Revolt](https://github.com/revoltchat) - Revolt is an open source user-first chat platform.
 
 * [OpenPaw](https://github.com/daxaur/openpaw) - Open-source AI-powered CLI that connects to Slack, Discord, Email, iMessage, WhatsApp, and Telegram from a single interface. Run via `npx pawmode`.


### PR DESCRIPTION
## HeyRobyn

Native macOS unified inbox that brings together email, Slack, and GitHub in one window.

**Website:** https://heyrobyn.ai

**Features:**
- Unified communication hub for email, Slack, and GitHub
- Native SwiftUI Mac app (not Electron)
- Privacy-first - all data processed on-device
- Multi-account support with keyboard shortcuts

**Why it belongs here:**
HeyRobyn fits alongside other communication tools like Franz and OpenPaw as a unified inbox solution for Mac users who need to manage multiple communication channels in one place.

Thanks for maintaining this list!