### PR TITLE
Add WhatsApp Readonly Bridge to Chat and messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ A curated list of open source, multiplatform and self hosted communication tools
 
 * [OpenPaw](https://github.com/daxaur/openpaw) - Open-source AI-powered CLI that connects to Slack, Discord, Email, iMessage, WhatsApp, and Telegram from a single interface. Run via `npx pawmode`.
 
+* [WhatsApp Readonly Bridge](https://github.com/MarketingBoer/whatsapp-readonly-bridge) - Zero-dependency Python bridge that receives WhatsApp messages via the official Meta Cloud API and saves them to a JSONL file. Includes Telegram digest for team discussion. Read-only by design.
+
 
 ## Chat bots
 * [Rasa](https://rasa.com/) - Rasa Open Source is a machine learning framework to automate text- and voice-based assistants.


### PR DESCRIPTION
Added WhatsApp Readonly Bridge — a zero-dependency Python bridge that receives WhatsApp messages via the official Meta Cloud API and saves them to a JSONL file. Includes Telegram digest for team discussion.

- Uses official Meta Cloud API (not Baileys)
- Read-only by design
- MIT licensed
- https://github.com/MarketingBoer/whatsapp-readonly-bridge