### PR TITLE
Add BChat to Chat and Messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ A curated list of open source, multiplatform and self hosted communication tools
 
 * [WhatsApp Readonly Bridge](https://github.com/MarketingBoer/whatsapp-readonly-bridge) - Zero-dependency Python bridge that receives WhatsApp messages via the official Meta Cloud API and saves them to a JSONL file. Includes Telegram digest for team discussion. Read-only by design.
 
+* [BChat](https://bchat.beldex.io/) - BChat is a privacy messaging app built on the Beldex blockchain that does not require personal identifiers, such as phone numbers or email addresses.
+
 
 ## Chat bots
 * [Rasa](https://rasa.com/) - Rasa Open Source is a machine learning framework to automate text- and voice-based assistants.


### PR DESCRIPTION
BChat is a privacy messaging app built on the Beldex blockchain that does not require personal identifiers, such as phone numbers or email addresses. It leverages onion routing and end-to-end encryption to ensure that user communications remain secure, private, and anonymous. By using a decentralised masternode architecture, it eliminates the need for a central authority, giving users full control over their data.

Website: [https://bchat.beldex.io/](url)

GitHub repository 

Android: [https://github.com/Beldex-Coin/bchat-android](url)
iOS: [https://github.com/Beldex-Coin/bchat-ios](url)
Desktop: [https://github.com/Beldex-Coin/bchat-desktop](url)