### PR TITLE
Add Weered to Chat and messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ A curated list of open source, multiplatform and self hosted communication tools
 
 * [BChat](https://bchat.beldex.io/) - BChat is a privacy messaging app built on the Beldex blockchain that does not require personal identifiers, such as phone numbers or email addresses.
 
+* [Weered](https://weered.ca) - Free Discord-style platform for gaming communities with lobbies, voice rooms, presence, and forums. Web and desktop (Windows, macOS, Linux).
+
 
 ## Chat bots
 * [Rasa](https://rasa.com/) - Rasa Open Source is a machine learning framework to automate text- and voice-based assistants.


### PR DESCRIPTION
Adds Weered, a free-to-use Discord-style platform for gaming communities (lobbies, voice rooms, forums, presence).

<img width="1908" height="951" alt="WeeredDPR" src="https://github.com/user-attachments/assets/fc5b3e0f-c741-4187-bb26-a6bf9a81cc75" />
<img width="1910" height="955" alt="WeeredHDPR" src="https://github.com/user-attachments/assets/f87a903a-7fc3-4bb6-8883-907344896728" />
<img width="1912" height="948" alt="weeredPR" src="https://github.com/user-attachments/assets/0ce8c38f-a229-42fd-a681-f9127b522f13" />
